### PR TITLE
Make TraceId implement CharSequence.

### DIFF
--- a/mats-api/src/main/java/io/mats3/MatsInitiator.java
+++ b/mats-api/src/main/java/io/mats3/MatsInitiator.java
@@ -44,7 +44,11 @@ public interface MatsInitiator extends Closeable {
 
     /**
      * Initiates a new message ("request" or "send") out to an endpoint: You provide a lambda which is supplied the
-     * {@link MatsInitiate} instance on which you invoke methods to construct and dispatch messages.
+     * {@link MatsInitiate} instance on which you invoke methods to construct and dispatch messages. The
+     * {@link InitiateLambda#initiate(MatsInitiate)} will be invoked in a transactional context, which will also
+     * include database operations that are invoked inside the lambda if the transaction manager for the MatsFactory
+     * is also used for database operations. This also implies that either all messages produced in the lambda will
+     * be sent, or none will.
      *
      * @param lambda
      *            provides the {@link MatsInitiate} instance on which to create the message to be sent.

--- a/mats-util/src/test/java/io/mats3/util/Test_TraceId.java
+++ b/mats-util/src/test/java/io/mats3/util/Test_TraceId.java
@@ -68,4 +68,94 @@ public class Test_TraceId {
         Assert.assertEquals("Prefix|Order.placeOrder:calcShipping[batch=abcde][cid=123456][oid=654321]", nonRandom);
     }
 
+    @Test
+    public void removeBatchId() {
+        String traceId = TraceId.create("Order", null, "calcShipping")
+                .add("cid", "123456").add("oid", "654321")
+                .batchId("abcde")
+                .batchId(null).toString();
+        String nonRandom = traceId.substring(0, traceId.length() - 6);
+        Assert.assertEquals("Order:calcShipping[cid=123456][oid=654321]", nonRandom);
+    }
+
+    @Test
+    public void updateKeyValue() {
+        String traceId = TraceId.create("Order", null, "calcShipping")
+                .add("cid", "123456")
+                // Change the cid key
+                .add("cid", "654321")
+                .toString();
+        String nonRandom = traceId.substring(0, traceId.length() - 6);
+        Assert.assertEquals("Order:calcShipping[cid=654321]", nonRandom);
+    }
+
+    // Common TraceId used in all charSequence API tests.
+    private final TraceId charSequnceTestTraceId = TraceId.create("Order", null, "calcShipping")
+            .add("cid", "123456").add("oid", "654321")
+            .batchId("abcde");
+
+    @Test
+    public void charSequnceCharAt() {
+        String traceIdText = charSequnceTestTraceId.toString();
+        for (int i = 0; i < traceIdText.length(); i++) {
+            Assert.assertEquals(traceIdText.charAt(i), charSequnceTestTraceId.charAt(i));
+        }
+    }
+
+    @Test
+    public void charSequnceCharAtBoundsCheck() {
+        Assert.assertThrows(IndexOutOfBoundsException.class,
+                () -> charSequnceTestTraceId.charAt(1000));
+        Assert.assertThrows(IndexOutOfBoundsException.class,
+                () -> charSequnceTestTraceId.charAt(charSequnceTestTraceId.length()));
+    }
+
+    @Test
+    public void charSequnceLength() {
+        String traceIdText = charSequnceTestTraceId.toString();
+        Assert.assertEquals(traceIdText.length(), charSequnceTestTraceId.length());
+    }
+
+    @Test
+    public void charSequenceLengthIncludesAddedKeyValue() {
+        int originalLength = charSequnceTestTraceId.length();
+        charSequnceTestTraceId.add("pid", "123456");
+        int lengthAfterAdd = charSequnceTestTraceId.length();
+        Assert.assertEquals(originalLength + 12, lengthAfterAdd);
+    }
+    @Test
+    public void charSequenceLenghtIncludesBatchId() {
+        int originalLength = charSequnceTestTraceId.length();
+        charSequnceTestTraceId.batchId(123456L); // 1 additional character
+        int lengthAfterAdd = charSequnceTestTraceId.length();
+        Assert.assertEquals(originalLength + 1, lengthAfterAdd);
+
+        charSequnceTestTraceId.batchId(null); // Clear BatchId
+        int lengthAfterRemove = charSequnceTestTraceId.length();
+        // [batch= + ] is 8 characters, test batchId is 5 characters. Removing batchId, removes 13 characters.
+        Assert.assertEquals(originalLength - 13, lengthAfterRemove);
+    }
+
+    @Test
+    public void charSequenceSubSequence() {
+        String traceIdText = charSequnceTestTraceId.toString();
+        for (int i = 0; i < traceIdText.length() - 5; i++) {
+            for (int j = i + 5; j < traceIdText.length(); j++) {
+                Assert.assertEquals(traceIdText.subSequence(i, j), charSequnceTestTraceId.subSequence(i, j));
+            }
+        }
+    }
+
+    @Test
+    public void charSequenceSubSequenceFullIdentity() {
+        CharSequence subSequenceFull = charSequnceTestTraceId.subSequence(0, charSequnceTestTraceId.length());
+        Assert.assertSame(charSequnceTestTraceId, subSequenceFull);
+    }
+
+    @Test
+    public void charSequenceBoundsCheck() {
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> charSequnceTestTraceId.subSequence(1000, 1001));
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> charSequnceTestTraceId.subSequence(0, 1001));
+        Assert.assertThrows(IllegalArgumentException.class, () -> charSequnceTestTraceId.subSequence(10, 0));
+    }
 }


### PR DESCRIPTION
This refactors the TraceId a bit, and in particular results in a TraceId
instance to always have the same randomPart (before this was generated
on each toString call).

All the fields in the TraceId are now initialized, so that we can
implement the CharSequence interface. Rather than just relying on
toString for this, each method is implemented as a function on top of
the array of CharSequences within the TraceId.

Change-Id: I711fc685e86c462a0be1216530aa07c1745cfec1