### PR TITLE
Mats init transaction doc

### DIFF
--- a/mats-api/src/main/java/io/mats3/MatsInitiator.java
+++ b/mats-api/src/main/java/io/mats3/MatsInitiator.java
@@ -46,7 +46,11 @@ public interface MatsInitiator extends Closeable {
 
     /**
      * Initiates a new message ("request" or "send") out to an endpoint: You provide a lambda which is supplied the
-     * {@link MatsInitiate} instance on which you invoke methods to construct and dispatch messages.
+     * {@link MatsInitiate} instance on which you invoke methods to construct and dispatch messages. The
+     * {@link InitiateLambda#initiate(MatsInitiate)} will be invoked in a transactional context, which will also
+     * include database operations that are invoked inside the lambda if the transaction manager for the MatsFactory
+     * is also used for database operations. This also implies that either all messages produced in the lambda will
+     * be sent, or none will.
      *
      * @param lambda
      *            provides the {@link MatsInitiate} instance on which to create the message to be sent.


### PR DESCRIPTION
Added documentation on the MatsI initiate that the initiation lambda will be invoked in a transactional context.