### PR TITLE
Renamed and moved MatsAnnotatedClass

### DIFF
--- a/mats-spring-test/build.gradle
+++ b/mats-spring-test/build.gradle
@@ -28,11 +28,6 @@ dependencies {
     // JMS API - since you must pull in a JMS Client, which thus provides the JMS API, we use compileOnly.
     compileOnly "$jmsApiDependency"
 
-    // For Extension_MatsSpring, mats-test-jupiter is needed. However, this is an optional dependency, and without
-    // it, it does not make sense to use Extension_MatsSpring.
-    compileOnly project(":mats-test-jupiter")
-    compileOnly project(":mats-test-junit")
-
     // :: TEST
 
     // @Inject

--- a/mats-test-junit/build.gradle
+++ b/mats-test-junit/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     testImplementation project(':mats-util')
     testImplementation project(':mats-test-broker')
 
+    // To test MatsAnnotatedClass
+    testImplementation project(':mats-spring')
+
     // ..Removed in Java 11
     testImplementation "javax.annotation:javax.annotation-api:$javaxAnnotationVersion"
 
@@ -41,6 +44,8 @@ dependencies {
     // Single Spring test inside
     testImplementation "org.springframework:spring-test:$springVersion"
     testImplementation "org.springframework:spring-context:$springVersion"
+    testImplementation "org.springframework:spring-tx:$springVersion"
+
 }
 
 publishing {

--- a/mats-test-junit/src/main/java/io/mats3/test/junit/Rule_MatsAnnotatedClass.java
+++ b/mats-test-junit/src/main/java/io/mats3/test/junit/Rule_MatsAnnotatedClass.java
@@ -1,11 +1,11 @@
-package io.mats3.spring.test;
+package io.mats3.test.junit;
 
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
 
 import io.mats3.MatsFactory;
-import io.mats3.test.jupiter.Extension_Mats;
+import io.mats3.test.abstractunit.AbstractMatsAnnotatedClass;
 
 /**
  * Helper class to test classes annotated with Mats annotations.
@@ -29,44 +29,45 @@ import io.mats3.test.jupiter.Extension_Mats;
  * This will still allow for an integration test of the Mats endpoint, checking annotations, and that state and
  * dtos can be serialized if needed.
  *
- * @author Ståle Undheim, 2023.09.13 stale.undheim@storebrand.no
+ * @author Ståle Undheim <stale.undheim@storebrand.no> 2024-11-21
  */
-public final class Extension_MatsSpring extends AbstractMatsSpring implements BeforeEachCallback, AfterEachCallback {
+public class Rule_MatsAnnotatedClass extends AbstractMatsAnnotatedClass implements MethodRule {
 
-
-    private Extension_MatsSpring(Extension_Mats extensionMats) {
-        super(extensionMats);
+    private Rule_MatsAnnotatedClass(Rule_Mats ruleMats) {
+        super(ruleMats);
     }
 
     /**
-     * Create a new Extension_MatsSpring instance, register to Junit using
-     * {@link org.junit.jupiter.api.extension.RegisterExtension}.
-     * @param extensionMats {@link Extension_Mats} to read the {@link MatsFactory} from.
-     * @return a new {@link Extension_MatsSpring}
+     * Create a new Rule_MatsSpring instance, register to Junit using
+     * {@link org.junit.Rule}.
+     * @param ruleMats {@link Rule_Mats} to read the {@link MatsFactory} from.
+     * @return a new {@link Rule_MatsAnnotatedClass}
      */
-    public static Extension_MatsSpring create(Extension_Mats extensionMats) {
-        return new Extension_MatsSpring(extensionMats);
+    public static Rule_MatsAnnotatedClass create(Rule_Mats ruleMats) {
+        return new Rule_MatsAnnotatedClass(ruleMats);
     }
 
     /**
      * Add classes to act as a source for annotations to register Mats endpoints for each test.
+     *
      */
-    @Override
-    public Extension_MatsSpring withClasses(Class<?>... annotatedMatsClasses) {
-        super.withClasses(annotatedMatsClasses);
+    public Rule_MatsAnnotatedClass withClasses(Class<?>... annotatedMatsClasses) {
+        super.addClasses(annotatedMatsClasses);
         return this;
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
-    // AvoidAccessibilityAlteration - need to reflect into test class to get fields.
-    public void beforeEach(ExtensionContext extensionContext) {
-        beforeEach(extensionContext.getTestInstance().orElse(null));
+    public Statement apply(Statement base, FrameworkMethod method, Object target) {
+        return new Statement() {
+            public void evaluate() throws Throwable {
+                beforeEach(target);
+                try {
+                    base.evaluate();
+                }
+                finally {
+                    afterEach();
+                }
+            }
+        };
     }
-
-    @Override
-    public void afterEach(ExtensionContext context) {
-        afterEach();
-    }
-
 }

--- a/mats-test-junit/src/main/java/io/mats3/test/junit/Rule_MatsAnnotatedClass.java
+++ b/mats-test-junit/src/main/java/io/mats3/test/junit/Rule_MatsAnnotatedClass.java
@@ -51,8 +51,16 @@ public class Rule_MatsAnnotatedClass extends AbstractMatsAnnotatedClass implemen
      * Add classes to act as a source for annotations to register Mats endpoints for each test.
      *
      */
-    public Rule_MatsAnnotatedClass withClasses(Class<?>... annotatedMatsClasses) {
-        super.addClasses(annotatedMatsClasses);
+    public Rule_MatsAnnotatedClass withAnnotatedMatsClasses(Class<?>... annotatedMatsClasses) {
+        super.registerMatsAnnotatedClasses(annotatedMatsClasses);
+        return this;
+    }
+
+    /**
+     * Add instances of classes annotated with Mats annotations to register Mats endpoints for each test.
+     */
+    public Rule_MatsAnnotatedClass withAnnotatedMatsInstances(Object... annotatedMatsInstances) {
+        super.registerMatsAnnotatedInstances(annotatedMatsInstances);
         return this;
     }
 

--- a/mats-test-junit/src/test/java/io/mats3/test/junit/U_RuleMatsAnnotatedClassTest.java
+++ b/mats-test-junit/src/test/java/io/mats3/test/junit/U_RuleMatsAnnotatedClassTest.java
@@ -1,0 +1,107 @@
+package io.mats3.test.junit;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.inject.Inject;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.mats3.spring.Dto;
+import io.mats3.spring.MatsMapping;
+import io.mats3.util.MatsFuturizer.Reply;
+
+/**
+ * Test of {@link Rule_MatsAnnotatedClass}
+ *
+ * @author Ståle Undheim <stale.undheim@storebrand.no> 2025-01-09
+ */
+public class U_RuleMatsAnnotatedClassTest {
+
+    @ClassRule
+    public static final Rule_Mats MATS = Rule_Mats.create();
+    public static final String ENDPOINT_ID = "AnnotatedEndpoint";
+
+    public static class ServiceDependency {
+        String formatMessage(String msg) {
+            return "Hello " + msg;
+        }
+    }
+
+    public static class MatsAnnotatedClass_Endpoint {
+
+        private ServiceDependency _serviceDependency;
+
+        public MatsAnnotatedClass_Endpoint() {
+
+        }
+
+        @Inject
+        public MatsAnnotatedClass_Endpoint(ServiceDependency serviceDependency) {
+            _serviceDependency = serviceDependency;
+        }
+
+        @MatsMapping(ENDPOINT_ID)
+        public String matsEndpoint(@Dto String msg) {
+            return _serviceDependency.formatMessage(msg);
+        }
+
+    }
+
+    // This dependency will be picked up by Extension_MatsAnnotatedClass, and result in injecting this
+    // instance into the service. This would also work if this was instead a Mockito mock.
+    private final ServiceDependency _serviceDependency = new ServiceDependency();
+
+    @Rule
+    public final Rule_MatsAnnotatedClass _matsAnnotationRule = Rule_MatsAnnotatedClass.create(MATS);
+
+    /**
+     * Example of adding a mats annotated class inside a test case, that will then be created and started.
+     */
+    @Test
+    public void testAnnotatedMatsClass() throws ExecutionException, InterruptedException, TimeoutException {
+        // :: Setup
+        _matsAnnotationRule.withAnnotatedMatsClasses(MatsAnnotatedClass_Endpoint.class);
+        String expectedReturn = "Hello World!";
+
+        // :: Act
+        String reply = callMatsAnnotatedEndpoint("World!");
+
+        // :: Verify
+        Assert.assertEquals(expectedReturn, reply);
+    }
+
+    /**
+     * Example of using an already instantiated Mats annotated class inside a test method.
+     */
+    @Test
+    public void testAnnotatedMatsInstance() throws ExecutionException, InterruptedException, TimeoutException {
+        // :: Setup
+        MatsAnnotatedClass_Endpoint annotatedMatsInstance = new MatsAnnotatedClass_Endpoint(_serviceDependency);
+        _matsAnnotationRule.withAnnotatedMatsInstances(annotatedMatsInstance);
+        String expectedReturn = "Hello World!";
+
+        // :: Act
+        String reply = callMatsAnnotatedEndpoint("World!");
+
+        // :: Verify
+        Assert.assertEquals(expectedReturn, reply);
+    }
+
+    private static String callMatsAnnotatedEndpoint(String message)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return MATS.getMatsFuturizer().futurizeNonessential(
+                        "invokeAnnotatedEndpoint",
+                        U_RuleMatsAnnotatedClassTest.class.getSimpleName(),
+                        ENDPOINT_ID,
+                        String.class,
+                        message)
+                .thenApply(Reply::getReply)
+                .get(10, TimeUnit.SECONDS);
+    }
+
+}

--- a/mats-test-jupiter/build.gradle
+++ b/mats-test-jupiter/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     testImplementation project(':mats-util')
     testImplementation project(':mats-test-broker')
 
+    // To test MatsAnnotatedClass
+    testImplementation project(':mats-spring')
+
     // ..Removed in Java 11
     testImplementation "javax.annotation:javax.annotation-api:$javaxAnnotationVersion"
 
@@ -43,6 +46,7 @@ dependencies {
         exclude group:'junit', module:'junit'
     }
     testImplementation "org.springframework:spring-context:$springVersion"
+    testImplementation "org.springframework:spring-tx:$springVersion"
 
     // The Jupiter Runtime..?
     testImplementation "org.junit.jupiter:junit-jupiter-api:$jupiterVersion"

--- a/mats-test-jupiter/src/main/java/io/mats3/test/jupiter/Extension_MatsAnnotatedClass.java
+++ b/mats-test-jupiter/src/main/java/io/mats3/test/jupiter/Extension_MatsAnnotatedClass.java
@@ -52,10 +52,19 @@ public final class Extension_MatsAnnotatedClass extends AbstractMatsAnnotatedCla
     /**
      * Add classes to act as a source for annotations to register Mats endpoints for each test.
      */
-    public Extension_MatsAnnotatedClass withClasses(Class<?>... annotatedMatsClasses) {
-        addClasses(annotatedMatsClasses);
+    public Extension_MatsAnnotatedClass withAnnotatedMatsClasses(Class<?>... annotatedMatsClasses) {
+        registerMatsAnnotatedClasses(annotatedMatsClasses);
         return this;
     }
+
+    /**
+     * Add instances of classes annotated with Mats annotations to register Mats endpoints for each test.
+     */
+    public Extension_MatsAnnotatedClass withAnnotatedMatsInstances(Object... annotatedMatsInstances) {
+        super.registerMatsAnnotatedInstances(annotatedMatsInstances);
+        return this;
+    }
+
 
     @Override
     @SuppressWarnings("PMD.AvoidAccessibilityAlteration")

--- a/mats-test-jupiter/src/main/java/io/mats3/test/jupiter/Extension_MatsAnnotatedClass.java
+++ b/mats-test-jupiter/src/main/java/io/mats3/test/jupiter/Extension_MatsAnnotatedClass.java
@@ -1,11 +1,11 @@
-package io.mats3.spring.test;
+package io.mats3.test.jupiter;
 
-import org.junit.rules.MethodRule;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.mats3.MatsFactory;
-import io.mats3.test.junit.Rule_Mats;
+import io.mats3.test.abstractunit.AbstractMatsAnnotatedClass;
 
 /**
  * Helper class to test classes annotated with Mats annotations.
@@ -29,45 +29,44 @@ import io.mats3.test.junit.Rule_Mats;
  * This will still allow for an integration test of the Mats endpoint, checking annotations, and that state and
  * dtos can be serialized if needed.
  *
- * @author Ståle Undheim <stale.undheim@storebrand.no> 2024-11-21
+ * @author Ståle Undheim, 2023.09.13 stale.undheim@storebrand.no
  */
-public class Rule_MatsSpring extends AbstractMatsSpring implements MethodRule {
+public final class Extension_MatsAnnotatedClass extends AbstractMatsAnnotatedClass
+        implements BeforeEachCallback, AfterEachCallback {
 
-    private Rule_MatsSpring(Rule_Mats ruleMats) {
-        super(ruleMats);
+
+    private Extension_MatsAnnotatedClass(Extension_Mats extensionMats) {
+        super(extensionMats);
     }
 
     /**
-     * Create a new Rule_MatsSpring instance, register to Junit using
-     * {@link org.junit.Rule}.
-     * @param ruleMats {@link Rule_Mats} to read the {@link MatsFactory} from.
-     * @return a new {@link Rule_MatsSpring}
+     * Create a new Extension_MatsSpring instance, register to Junit using
+     * {@link org.junit.jupiter.api.extension.RegisterExtension}.
+     * @param extensionMats {@link Extension_Mats} to read the {@link MatsFactory} from.
+     * @return a new {@link Extension_MatsAnnotatedClass}
      */
-    public static Rule_MatsSpring create(Rule_Mats ruleMats) {
-        return new Rule_MatsSpring(ruleMats);
+    public static Extension_MatsAnnotatedClass create(Extension_Mats extensionMats) {
+        return new Extension_MatsAnnotatedClass(extensionMats);
     }
 
     /**
      * Add classes to act as a source for annotations to register Mats endpoints for each test.
      */
-    @Override
-    public Rule_MatsSpring withClasses(Class<?>... annotatedMatsClasses) {
-        super.withClasses(annotatedMatsClasses);
+    public Extension_MatsAnnotatedClass withClasses(Class<?>... annotatedMatsClasses) {
+        addClasses(annotatedMatsClasses);
         return this;
     }
 
     @Override
-    public Statement apply(Statement base, FrameworkMethod method, Object target) {
-        return new Statement() {
-            public void evaluate() throws Throwable {
-                beforeEach(target);
-                try {
-                    base.evaluate();
-                }
-                finally {
-                    afterEach();
-                }
-            }
-        };
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    // AvoidAccessibilityAlteration - need to reflect into test class to get fields.
+    public void beforeEach(ExtensionContext extensionContext) {
+        beforeEach(extensionContext.getTestInstance().orElse(null));
     }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        afterEach();
+    }
+
 }

--- a/mats-test-jupiter/src/test/java/io/mats3/test/jupiter/J_ExtensionMatsAnnotatedClassTest.java
+++ b/mats-test-jupiter/src/test/java/io/mats3/test/jupiter/J_ExtensionMatsAnnotatedClassTest.java
@@ -1,0 +1,161 @@
+package io.mats3.test.jupiter;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.mats3.spring.Dto;
+import io.mats3.spring.MatsMapping;
+import io.mats3.util.MatsFuturizer.Reply;
+
+/**
+ * Test of {@link Extension_MatsAnnotatedClass}, with example of adding annotated classes when the extension is
+ * created, or within each test method.
+ *
+ * @author Ståle Undheim <stale.undheim@storebrand.no> 2025-01-09
+ */
+class J_ExtensionMatsAnnotatedClassTest {
+
+    @RegisterExtension
+    private static final Extension_Mats MATS = Extension_Mats.create();
+    public static final String ENDPOINT_ID = "AnnotatedEndpoint";
+
+    public static class ServiceDependency {
+        String formatMessage(String msg) {
+            return "Hello " + msg;
+        }
+    }
+
+    public static class MatsAnnotatedClass_Endpoint {
+
+        private ServiceDependency _serviceDependency;
+
+        public MatsAnnotatedClass_Endpoint() {
+
+        }
+
+        @Inject
+        public MatsAnnotatedClass_Endpoint(ServiceDependency serviceDependency) {
+            _serviceDependency = serviceDependency;
+        }
+
+        @MatsMapping(ENDPOINT_ID)
+        public String matsEndpoint(@Dto String msg) {
+            return _serviceDependency.formatMessage(msg);
+        }
+
+    }
+
+    // This dependency will be picked up by Extension_MatsAnnotatedClass, and result in injecting this
+    // instance into the service. This would also work if this was instead a Mockito mock.
+    private final ServiceDependency _serviceDependency = new ServiceDependency();
+
+
+    /**
+     * Example for how to provide a class with annotated MatsEndpoints to test.
+     */
+    @Nested
+    class TestAnnotatedWithProvidedClass {
+        @RegisterExtension
+        private final Extension_MatsAnnotatedClass _matsAnnotatedClassExtension = Extension_MatsAnnotatedClass
+                .create(MATS)
+                .withAnnotatedMatsClasses(MatsAnnotatedClass_Endpoint.class);
+
+        @Test
+        void testAnnotatedMatsClass() throws ExecutionException, InterruptedException, TimeoutException {
+            // :: Setup
+            String expectedReturn = "Hello World!";
+
+            // :: Act
+            String reply = callMatsAnnotatedEndpoint("World!");
+
+            // :: Verify
+            Assertions.assertEquals(expectedReturn, reply);
+        }
+    }
+
+    /**
+     * Example for how to provide an instance of an annotated class with MatsEndpoints to test.
+     */
+    @Nested
+    class TestAnnotatedWithProvidedInstance {
+
+        @RegisterExtension
+        private final Extension_MatsAnnotatedClass _matsAnnotatedClassExtension = Extension_MatsAnnotatedClass
+                .create(MATS)
+                .withAnnotatedMatsInstances(new MatsAnnotatedClass_Endpoint(_serviceDependency));
+
+        @Test
+        void testAnnotatedMatsInstance() throws ExecutionException, InterruptedException, TimeoutException {
+            // :: Setup
+            String expectedReturn = "Hello World!";
+
+            // :: Act
+            String reply = callMatsAnnotatedEndpoint("World!");
+
+            // :: Verify
+            Assertions.assertEquals(expectedReturn, reply);
+        }
+    }
+
+    /**
+     * These tests demonstrate that we can add new annotated classes within a test.
+     */
+    @Nested
+    class TestAnnotatedWithDelayedConfiguration {
+
+        @RegisterExtension
+        private final Extension_MatsAnnotatedClass _matsAnnotatedClassExtension
+                = Extension_MatsAnnotatedClass.create(MATS);
+
+        @Test
+        void testAnnotatedMatsClass() throws ExecutionException, InterruptedException, TimeoutException {
+            // :: Setup
+            _matsAnnotatedClassExtension.withAnnotatedMatsClasses(MatsAnnotatedClass_Endpoint.class);
+            String expectedReturn = "Hello World!";
+
+            // :: Act
+            String reply = callMatsAnnotatedEndpoint("World!");
+
+            // :: Verify
+            Assertions.assertEquals(expectedReturn, reply);
+        }
+
+
+        @Test
+        void testAnnotatedMatsInstance() throws ExecutionException, InterruptedException, TimeoutException {
+            // :: Setup
+            MatsAnnotatedClass_Endpoint annotatedClassInstance =
+                    new MatsAnnotatedClass_Endpoint(_serviceDependency);
+            _matsAnnotatedClassExtension.withAnnotatedMatsInstances(annotatedClassInstance);
+            String expectedReturn = "Hello World!";
+
+            // :: Act
+            String reply = callMatsAnnotatedEndpoint("World!");
+
+            // :: Verify
+            Assertions.assertEquals(expectedReturn, reply);
+        }
+    }
+
+    private String callMatsAnnotatedEndpoint(String message)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return MATS.getMatsFuturizer().futurizeNonessential(
+                        "invokeAnnotatedEndpoint",
+                        getClass().getSimpleName(),
+                        ENDPOINT_ID,
+                        String.class,
+                        message)
+                .thenApply(Reply::getReply)
+                .get(10, TimeUnit.SECONDS);
+    }
+
+
+}

--- a/mats-test/build.gradle
+++ b/mats-test/build.gradle
@@ -35,6 +35,11 @@ dependencies {
     // H2 Database, for database tests - but we do not want to make this dependency transitive, so compileOnly.
     compileOnly "com.h2database:h2:$h2Version"
 
+    // Spring dependencies for MatsAnnotatedClasses. This is compileOnly, as if you are not using Spring, then
+    // you should not need this.
+    compileOnly "org.springframework:spring-context:$springVersion"
+    compileOnly project(':mats-spring')
+
     // === TEST
     testImplementation "junit:junit:$junitVersion"
 }

--- a/mats-test/src/main/java/io/mats3/test/abstractunit/AbstractMatsAnnotatedClass.java
+++ b/mats-test/src/main/java/io/mats3/test/abstractunit/AbstractMatsAnnotatedClass.java
@@ -1,4 +1,4 @@
-package io.mats3.spring.test;
+package io.mats3.test.abstractunit;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,28 +13,28 @@ import org.springframework.util.ReflectionUtils;
 import io.mats3.MatsEndpoint;
 import io.mats3.MatsFactory;
 import io.mats3.spring.MatsSpringAnnotationRegistration;
-import io.mats3.test.abstractunit.AbstractMatsTest;
 
 /**
- * Implementation for use in {@link Extension_MatsSpring}
+ * Base class used in specific test runtimes to support testing of classes annotated with Mats annotations.
+ *
+ * @author Ståle Undheim <stale.undheim@storebrand.no> 2025-01-09
  */
-public class AbstractMatsSpring {
+public class AbstractMatsAnnotatedClass {
 
 
     private final AbstractMatsTest _matsTest;
     private final List<MatsEndpoint<?, ?>> _endpoints = new ArrayList<>();
     private final List<Class<?>> _annotatedMatsClasses = new ArrayList<>();
 
-    protected AbstractMatsSpring(AbstractMatsTest matsTest) {
+    protected AbstractMatsAnnotatedClass(AbstractMatsTest matsTest) {
         _matsTest = matsTest;
     }
 
     /**
      * Add classes to act as a source for annotations to register Mats endpoints for each test.
      */
-    public AbstractMatsSpring withClasses(Class<?>... annotatedMatsClasses) {
+    public void addClasses(Class<?>... annotatedMatsClasses) {
         Collections.addAll(_annotatedMatsClasses, annotatedMatsClasses);
-        return this;
     }
 
     public void beforeEach(Object testInstance) {

--- a/mats-test/src/main/java/io/mats3/test/abstractunit/AbstractMatsAnnotatedClass.java
+++ b/mats-test/src/main/java/io/mats3/test/abstractunit/AbstractMatsAnnotatedClass.java
@@ -1,13 +1,12 @@
 package io.mats3.test.abstractunit;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.UnsatisfiedDependencyException;
+import org.springframework.beans.factory.annotation.AnnotatedGenericBeanDefinition;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.util.ReflectionUtils;
 
 import io.mats3.MatsEndpoint;
@@ -21,124 +20,136 @@ import io.mats3.spring.MatsSpringAnnotationRegistration;
  */
 public class AbstractMatsAnnotatedClass {
 
-
     private final AbstractMatsTest _matsTest;
-    private final List<MatsEndpoint<?, ?>> _endpoints = new ArrayList<>();
-    private final List<Class<?>> _annotatedMatsClasses = new ArrayList<>();
+
+    // List of endpoints that we have created. Since this util can be used in conjunction with other tools to create
+    // endpoints, we need to know which endpoint we created for a test, so that we can remove them after the test, but
+    // not remove unrelated endpoints.
+    private final List<MatsEndpoint<?, ?>> _registeredEndpoints = new ArrayList<>();
+
+    private final AnnotationConfigApplicationContext _applicationContext = new AnnotationConfigApplicationContext(
+            // Register the MatsSpringAnnotationRegistration, which is responsible for reading Mats annotations
+            MatsSpringAnnotationRegistration.class
+    );
+    private final List<String> _uninitializedBeans = new ArrayList<>();
 
     protected AbstractMatsAnnotatedClass(AbstractMatsTest matsTest) {
         _matsTest = matsTest;
     }
 
-    /**
-     * Add classes to act as a source for annotations to register Mats endpoints for each test.
-     */
-    public void addClasses(Class<?>... annotatedMatsClasses) {
-        Collections.addAll(_annotatedMatsClasses, annotatedMatsClasses);
+    public void beforeEach(Object testInstance) {
+        MatsFactory matsFactory = _matsTest.getMatsFactory();
+        // Note: we need to register the MatsFactory as a singleton, otherwise the MatsSpringAnnotationRegistration
+        //       will register the MatsFactory to the Spring context, and start it when the Spring context starts.
+        //       This will cause duplicate start of MatsFuturizer threads, which will throw IllegalStateException.
+        _applicationContext.getBeanFactory().registerSingleton("matsFactory", matsFactory);
+
+        // If we have a test instance, we register each non-null field as a singleton in the Spring context.
+        // This is so that those fields are available to inject into the Mats annotated classes.
+        if (testInstance != null) {
+            ReflectionUtils.doWithFields(testInstance.getClass(), field -> {
+                field.setAccessible(true);
+                String beanName = field.getName();
+                Object beanInstance = field.get(testInstance);
+
+                // ?: Is there no bean registered with this name, and we have a value for the field?
+                if (!_applicationContext.containsBean(beanName) && beanInstance != null) {
+                    // Yes -> add this to the Spring context as a singleton
+                    _applicationContext.getBeanFactory().registerSingleton(beanName, beanInstance);
+                }
+            });
+        }
+        initializeBeansAndRegisterEndpoints();
     }
 
-    public void beforeEach(Object testInstance) {
-        // If we have no classes, then early exit.
-        if (_annotatedMatsClasses.isEmpty()) {
-            return;
+    public void afterEach() {
+        for (MatsEndpoint<?, ?> endpoint : _registeredEndpoints) {
+            endpoint.remove(30_000);
         }
+        _applicationContext.close();
+    }
 
-        MatsFactory matsFactory = _matsTest.getMatsFactory();
-        try (AnnotationConfigApplicationContext applicationcontext = new AnnotationConfigApplicationContext()) {
-            // Register the MatsSpringAnnotationRegistration, which is responsible for reading Mats annotations
-            applicationcontext.registerBean(MatsSpringAnnotationRegistration.class);
-
-            // Note: we need to register the MatsFactory as a singleton, otherwise the MatsSpringAnnotationRegistration
-            //       will register the MatsFactory to the Spring context, and start it when the Spring context starts.
-            //       This will cause duplicate start of MatsFuturizer threads, which will throw IllegalStateException.
-            applicationcontext.getBeanFactory().registerSingleton("matsFactory", matsFactory);
-
-            for (Class<?> matsAnnotatedClass : _annotatedMatsClasses) {
-                String matsBeanName = matsAnnotatedClass.getSimpleName();
-                try {
-                    // Register the matsAnnotatedClass, and refresh the Spring context. This will cause the
-                    // MatsSpringAnnotationRegistration to read the Mats annotations, and register the endpoints
-                    // with the MatsFactory.
-                    applicationcontext.registerBean(matsBeanName, matsAnnotatedClass);
-                }
-                catch (UnsatisfiedDependencyException e) {
-                    // Add another wrapper to report this as a test failure, and provide some hints towards what
-                    // could be the cause for the UnsatisfiedDependencyException.
-                    throw new AssertionError("Failed to create bean of type [" + matsBeanName + "]"
-                                             + " with dependencies from test class fields."
-                                             + " Ensure that all dependencies are present as fields. Use @Mock with"
-                                             + " Mockito to initialize fields.", e);
-                }
-            }
-
-            // Register each dependency as a singleton, so that we can properly construct the matsAnnotatedClass
-            // from the Spring context.
-            if (testInstance != null) {
-                ReflectionUtils.doWithFields(testInstance.getClass(), field -> {
-                    field.setAccessible(true);
-                    String beanName = field.getName();
-                    Object beanInstance = field.get(testInstance);
-
-                    // ?: Is there no bean registered with this name, and we have a value for the field?
-                    if (!applicationcontext.containsBean(beanName) && beanInstance != null) {
-                        // Yes -> add this to the Spring context as a singleton
-                        applicationcontext.getBeanFactory().registerSingleton(beanName, beanInstance);
-                    }
-                });
-            }
-
-            // Capture current mats endpoint before we refresh the context, so that we can determine which endpoints
-            // are added when Spring refreshes the context. We need to know which endpoints are added, so that we can
-            // remove them after each test.
-            List<MatsEndpoint<?, ?>> initialEndpoints = matsFactory.getEndpoints();
-            applicationcontext.refresh();
-            matsFactory.getEndpoints().stream()
-                    .filter(endpoint -> !initialEndpoints.contains(endpoint))
-                    .forEach(_endpoints::add);
+    /**
+     * Add a class annotated with Mats annotations, so that it will be created and endpoints registered for each test.
+     */
+    public void registerMatsAnnotatedClasses(Class<?>... annotatedMatsClasses) {
+        for (Class<?> annotatedMatsClass : annotatedMatsClasses) {
+            addAnnotatedMatsBean(new AnnotatedGenericBeanDefinition(annotatedMatsClass));
         }
+        initializeBeansAndRegisterEndpoints();
     }
 
     /**
      * Add an already instantiated instance of a class annotated with Mats annotations to the MatsFactory
      *
-     * @param annotatedMatsBeans
+     * @param annotatedMatsInstances
      *         to introspect for annotations, and add to the MatsFactory.
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    // unchecked, rawtypes: Need to use unchecked and rawtypes here, as we really don't need to enforce generics here.
-    public void addAnnotatedMatsBeans(Object... annotatedMatsBeans) {
-        MatsFactory matsFactory = _matsTest.getMatsFactory();
+    public void registerMatsAnnotatedInstances(Object... annotatedMatsInstances) {
+        for (Object annotatedMatsInstance: annotatedMatsInstances) {
+            GenericBeanDefinition beanDefinition = new AnnotatedGenericBeanDefinition(annotatedMatsInstance.getClass());
+            beanDefinition.setInstanceSupplier(() -> annotatedMatsInstance);
 
-        try (StaticApplicationContext applicationContext = new StaticApplicationContext()) {
-            applicationContext.getBeanFactory().registerSingleton("matsFactory", matsFactory);
+            addAnnotatedMatsBean(beanDefinition);
+        }
+        initializeBeansAndRegisterEndpoints();
+    }
 
-            // Use the MatsSpringAnnotationRegistration to register the endpoints based on annotations on the class,
+    /**
+     * Internal method to register a bean with the Spring context, and add it to the list of beans that need to be
+     * initialized.
+     *
+     * @param beanDefinition to register with the Spring context.
+     */
+    private void addAnnotatedMatsBean(GenericBeanDefinition beanDefinition) {
+        String beanName = beanDefinition.getBeanClass().getSimpleName();
+
+        try {
+            // Register the matsAnnotatedClass, and refresh the Spring context. This will cause the
+            // MatsSpringAnnotationRegistration to read the Mats annotations, and register the endpoints
             // with the MatsFactory.
-            MatsSpringAnnotationRegistration matsSpringAnnotationRegistration = new MatsSpringAnnotationRegistration();
-            matsSpringAnnotationRegistration.setApplicationContext(applicationContext);
-
-            for (Object annotatedMatsBean : annotatedMatsBeans) {
-                Class beanClass = annotatedMatsBean.getClass();
-                String beanName = beanClass.getSimpleName();
-                applicationContext.registerBean(beanName, beanClass, () -> annotatedMatsBean);
-                matsSpringAnnotationRegistration.postProcessAfterInitialization(annotatedMatsBean, beanName);
-            }
-
-            // Capture the current endpoints prior to registering new endpoints
-            List<MatsEndpoint<?, ?>> initialEndpoints = matsFactory.getEndpoints();
-            // Register all endpoints with the MatsFactory that was added in the prior loop
-            matsSpringAnnotationRegistration.onContextRefreshedEvent(new ContextRefreshedEvent(applicationContext));
-
-            // Find the newly added endpoints, and add them to our list of endpoints to shut down after each test.
-            matsFactory.getEndpoints().stream()
-                    .filter(endpoint -> !initialEndpoints.contains(endpoint))
-                    .forEach(_endpoints::add);
+            _applicationContext.registerBeanDefinition(beanName, beanDefinition);
+            _uninitializedBeans.add(beanName);
+        }
+        catch (UnsatisfiedDependencyException e) {
+            // Add another wrapper to report this as a test failure, and provide some hints towards what
+            // could be the cause for the UnsatisfiedDependencyException.
+            throw new AssertionError("Failed to create bean of type [" + beanName + "]"
+                                     + " with dependencies from test class fields."
+                                     + " Ensure that all dependencies are present as fields. Use @Mock with"
+                                     + " Mockito to initialize fields.", e);
         }
     }
 
-    public void afterEach() {
-        for (MatsEndpoint<?, ?> endpoint : _endpoints) {
-            endpoint.remove(30_000);
+    /**
+     * Helper method to call after we have added one or more beans to the Spring context, that have not yet been
+     * initialized. This will force initialization of the beans, and register any new endpoints with the MatsFactory.
+     * If the application context has not yet been initialized, this will do nothing, and the beans will be initialized
+     * when the {@link #beforeEach(Object)} method is called.
+     */
+    private void initializeBeansAndRegisterEndpoints() {
+        // If this is called before the matsFactory is added to the application context, we cannot yet
+        // initialize the beans, as the MatsSpringAnnotationRegistration will not be able to register the
+        // endpoints with the MatsFactory.
+        // Also, if there are no beans to initialize, we can skip this.
+        if (!_applicationContext.containsBean("matsFactory") || _uninitializedBeans.isEmpty()) {
+            return;
         }
+
+        // We first need to capture the current set of endpoints, so that we can detect any new endpoints
+        // created by forcing the bean initialization.
+        MatsFactory matsFactory = _applicationContext.getBean(MatsFactory.class);
+        List<MatsEndpoint<?, ?>> initialEndpoints = matsFactory.getEndpoints();
+        // All beans that we create, will not be initialized, as nothing depends on them. So we force
+        // initialization by calling getBean on each of them.
+        _uninitializedBeans.forEach(_applicationContext::getBean);
+        _uninitializedBeans.clear();
+
+        List<MatsEndpoint<?, ?>> currentEndpoints = matsFactory.getEndpoints();
+        // Add all new endpoints that where created by initializing the beans.
+        currentEndpoints.stream()
+                .filter(endpoint -> !initialEndpoints.contains(endpoint))
+                .forEach(_registeredEndpoints::add);
     }
+
 }


### PR DESCRIPTION
The MatsAnnotatedClass Rule/Extension, is meant for use in pure Java tests, not involving Spring, even though it does use Spring internally to wire up the endpoint, and trigger parsing of the Mats annotated classes.

Also moved the Rule/Extension to the unit/jupiter test package respectivly, as this is a more logical place for pure Java test helpers.