### PR TITLE
Improved error message on double registration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ ext {
     jettyVersion = '9.4.56.v20240826'
     hibernateVersion = '5.6.15.Final' // Hibernate 6 depends on Jakarta.persistence. Holding back for now, 2023-10-27
     remockVersion = '2.0.0'
+    mockitoVersion = '5.15.2'
 
     // Need the JMS API to build several modules, but ONLY on 'compileOnly' and 'testCompileOnly'!
     // On runtime, the JMS API will be provided by the user. For tests, by 'mats-test' which includes an

--- a/mats-test-jupiter/build.gradle
+++ b/mats-test-jupiter/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$jupiterVersion"
     testImplementation "org.junit.platform:junit-platform-launcher:$jupiterPlatformVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$jupiterVersion"
+
+    // Mockito
+    testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
 }
 
 test {


### PR DESCRIPTION
As requested, an example using Mockito.

I added some more tests, and it occurred to me that we might want to have a nice error message on duplicate registrations, in case you register both in a top class and a nested class. This would have failed in any case (and does not make sense imho.). The entire test suite uses 1 MatsFactory, so it is global for all tests.