### PR TITLE
Minor fixes to tests

### DIFF
--- a/mats-test-junit/src/main/java/io/mats3/test/junit/Rule_MatsAnnotatedClass.java
+++ b/mats-test-junit/src/main/java/io/mats3/test/junit/Rule_MatsAnnotatedClass.java
@@ -1,5 +1,7 @@
 package io.mats3.test.junit;
 
+import java.util.Collections;
+
 import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
@@ -119,7 +121,7 @@ public class Rule_MatsAnnotatedClass extends AbstractMatsAnnotatedClass implemen
                 + "target [" + target + "], base [" + base + "]");
         return new Statement() {
             public void evaluate() throws Throwable {
-                beforeEach(target);
+                beforeEach(Collections.singletonList(target));
                 try {
                     base.evaluate();
                 }

--- a/mats-test-jupiter/src/main/java/io/mats3/test/jupiter/Extension_MatsAnnotatedClass.java
+++ b/mats-test-jupiter/src/main/java/io/mats3/test/jupiter/Extension_MatsAnnotatedClass.java
@@ -1,5 +1,10 @@
 package io.mats3.test.jupiter;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -102,7 +107,11 @@ public final class Extension_MatsAnnotatedClass extends AbstractMatsAnnotatedCla
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) {
-        beforeEach(extensionContext.getTestInstance().orElse(null));
+        List<Object> allInstances = new ArrayList<>(extensionContext.getRequiredTestInstances().getAllInstances());
+        // By default, the instance order is from the root to the leaf. We instead want the leaf first, so that
+        // fields there take precedence over fields higher up in the hierarchy.
+        Collections.reverse(allInstances);
+        beforeEach(allInstances);
     }
 
     @Override


### PR DESCRIPTION
These are a bunch of minor fixes, that where done while implementing annotation support for Mats testing in Jupiter.

* Use ExtensionContext to determine if we are in a nested class
* Go up the ExtensionContext hierachy to find Extension_Mats
* Use testInstances from ExtensionContext to find parent classes for nested test, and registering dependencies in Spring for MatsAnnotatedClass testing.